### PR TITLE
Shows message instead of exception in #177

### DIFF
--- a/binstar_client/utils/notebook/downloader.py
+++ b/binstar_client/utils/notebook/downloader.py
@@ -1,7 +1,7 @@
 import os
 from time import mktime
 from dateutil.parser import parse
-from ...errors import DestionationPathExists
+from binstar_client.errors import DestionationPathExists
 
 
 class Downloader(object):

--- a/binstar_client/utils/notebook/downloader.py
+++ b/binstar_client/utils/notebook/downloader.py
@@ -1,6 +1,7 @@
 import os
 from time import mktime
 from dateutil.parser import parse
+from ...errors import DestionationPathExists
 
 
 class Downloader(object):
@@ -23,6 +24,8 @@ class Downloader(object):
             if self.can_download(f, force):
                 self.download(f)
                 output.append(f['basename'])
+            else:
+                raise DestionationPathExists(f['basename'])
         return output
 
     def download(self, dist):


### PR DESCRIPTION
```
➜  tmp  binstar notebook download sean/conda_data-ipynb
Using binstar api site https://api.anaconda.org
destination path 'conda_data.ipynb' already exists.
➜  tmp  binstar notebook download sean/conda_data-ipynb --force
Using binstar api site https://api.anaconda.org
sean/conda_data-ipynb has been downloaded as conda_data.ipynb.
```
@srossross @LilaHickey 